### PR TITLE
Bump to v0.1.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-gemini",
-    version="0.1.1",
+    version="0.1.2",
     description="Singer.io tap for extracting data from Yahoo Gemini",
     author="Joe Heffer",
     url="https://github.com/singer-io/tap-gemini",


### PR DESCRIPTION
# Description of change
See #6 

# Manual QA steps
 - See #6 
 
# Risks
 - Low, since the tap is already in an error state
 
# Rollback steps
 - revert #6 and bump version
