### PR TITLE
Disable load_key_properties()

### DIFF
--- a/tap_gemini/__init__.py
+++ b/tap_gemini/__init__.py
@@ -164,7 +164,9 @@ def discover() -> singer.Catalog:
 
     raw_schemas = load_schemas()
     metadata = load_metadata()
-    key_properties = load_key_properties()
+    # Disable key properties to avoid file-not-found errors because these aren't used
+    #key_properties = load_key_properties()
+    key_properties = dict()
 
     streams = list()
 


### PR DESCRIPTION
# Description of change
The key_properties directory is not used, so disable loading that directory to avoid file-not-found errors

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
