### PR TITLE
Fetch advertiser IDs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-gemini",
-    version="0.1.3",
+    version="0.1.4",
     description="Singer.io tap for extracting data from Yahoo Gemini",
     author="Joe Heffer",
     url="https://github.com/singer-io/tap-gemini",

--- a/tap_gemini/__init__.py
+++ b/tap_gemini/__init__.py
@@ -164,7 +164,9 @@ def discover() -> singer.Catalog:
 
     raw_schemas = load_schemas()
     metadata = load_metadata()
-    key_properties = load_key_properties()
+    # Disable key properties to avoid file-not-found errors because these aren't used
+    #key_properties = load_key_properties()
+    key_properties = dict()
 
     streams = list()
 

--- a/tap_gemini/report.py
+++ b/tap_gemini/report.py
@@ -18,6 +18,7 @@ LOGGER = logging.getLogger(__name__)
 
 REPORT_ENDPOINT = 'reports'
 CUSTOM_REPORT_ENDPOINT = REPORT_ENDPOINT + '/custom'
+DEFAULT_POLL_INTERVAL = 1.0
 
 
 class BooksClosedNotImplementedError(NotImplementedError):
@@ -34,7 +35,7 @@ class GeminiReport:
 
     def __init__(self, session, advertiser_ids: list, cube: str, field_names: list,
                  start_date: datetime.date, end_date: datetime.date = None, filters: list = None,
-                 poll_interval: float = 1.0):
+                 poll_interval: float = None):
         self.advertiser_ids = advertiser_ids
         self.cube = cube
         self.field_names = field_names
@@ -42,7 +43,7 @@ class GeminiReport:
         self.end_date = end_date or datetime.date.today()
         self.filters = filters or list()
         self.session = session
-        self.poll_interval = float(poll_interval)
+        self.poll_interval = float(poll_interval or DEFAULT_POLL_INTERVAL)
         self.job_id = None
         self.download_url = None
 


### PR DESCRIPTION
# Description of change
Instead of loading advertiser (account) ID numbers instead of loading from the configuration file. Also, the HTTP session is only initialised once, instead of being re-initialised for every stream that is synced.

When retreiving a report, the polling interval now defaults to one second if it is not manually specified in config.json.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
